### PR TITLE
Potential fix for code scanning alert no. 20: Log entries created from user input

### DIFF
--- a/src/api/Endpoints/TodoSkillsetEndpoints.cs
+++ b/src/api/Endpoints/TodoSkillsetEndpoints.cs
@@ -144,11 +144,12 @@ public static class TodoSkillsetEndpoints
                     logger.LogWarning("Todo with id {id} does not belong to user {userId}.", id, userId);
                     return Results.BadRequest();
                 }
-                logger.LogInformation("Deleting todo with id {id}.", id);
+                var sanitizedId = id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                logger.LogInformation("Deleting todo with id {id}.", sanitizedId);
                 var success = await repository.DeleteTodoAsync(id);
                 if (!success)
                 {
-                    logger.LogWarning("Todo with id {id} not found for deletion.", id);
+                    logger.LogWarning("Todo with id {id} not found for deletion.", sanitizedId);
                     return Results.NotFound();
                 }
                 logger.LogInformation("Todo deleted successfully.");


### PR DESCRIPTION
Potential fix for [https://github.com/congiuluc/GitHub-Copilot-Extension-Demo/security/code-scanning/20](https://github.com/congiuluc/GitHub-Copilot-Extension-Demo/security/code-scanning/20)

To fix the problem, we need to sanitize the `id` value before logging it. Since the log entries are plain text, we should remove any line breaks from the `id` to prevent log injection. This can be done using the `String.Replace` method to replace newline characters with an empty string.

The best way to fix the problem without changing existing functionality is to sanitize the `id` value right before it is logged. This ensures that any potentially malicious input is neutralized before it reaches the log.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
