### PR TITLE
Potential fix for code scanning alert no. 8: Log entries created from user input

### DIFF
--- a/src/api/Endpoints/TodoApiEndpoints.cs
+++ b/src/api/Endpoints/TodoApiEndpoints.cs
@@ -88,20 +88,21 @@ public static class TodoEndpoints
                 var task = await repository.GetTodoAsync(id);
                 if (task == null)
                 {
-                    logger.LogWarning("Todo with id {id} not found for update.", id);
+                    var sanitizedId = id.Replace(Environment.NewLine, "").Replace("\n", "").Replace("\r", "");
+                    logger.LogWarning("Todo with id {id} not found for update.", sanitizedId);
                     return Results.NotFound();
                 }
                 if (task.UserId != userId)
                 {
-                    logger.LogWarning("User {userId} is not authorized to update todo with id {id}.", userId, id);
+                    logger.LogWarning("User {userId} is not authorized to update todo with id {id}.", userId, sanitizedId);
                     return Results.BadRequest();
                 }
                 todo.UserId = userId;
-                logger.LogInformation("Updating todo with id {id}.", id);
+                logger.LogInformation("Updating todo with id {id}.", sanitizedId);
                 var updatedTodo = await repository.UpdateTodoAsync(todo);
                 if (updatedTodo == null)
                 {
-                    logger.LogWarning("Todo with id {id} not found for update.", id);
+                    logger.LogWarning("Todo with id {id} not found for update.", sanitizedId);
                     return Results.NotFound();
                 }
 


### PR DESCRIPTION
Potential fix for [https://github.com/congiuluc/GitHub-Copilot-Extension-Demo/security/code-scanning/8](https://github.com/congiuluc/GitHub-Copilot-Extension-Demo/security/code-scanning/8)

To fix the problem, we need to sanitize the `id` before logging it. This can be done by removing any newline characters from the `id` to prevent log forging. We will use the `Replace` method to remove newline characters from the `id` before logging it.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
